### PR TITLE
Attempt to fix except indentation issue

### DIFF
--- a/redbaron/base_nodes.py
+++ b/redbaron/base_nodes.py
@@ -1759,9 +1759,12 @@ class LineProxyList(ProxyList):
 
         def get_real_last(node):
             try:
-                return node.node_list[-1]
+                return node._get_last_member_to_clean()
             except:
-                return node[-1]
+                try:
+                    return node.node_list[-1]
+                except:
+                    return node[-1]
 
         def modify_last_indentation(node, indentation):
             try:

--- a/tests/test_proxy_list.py
+++ b/tests/test_proxy_list.py
@@ -1159,6 +1159,12 @@ def test_line_proxy_correctly_indent_code_block():
     assert red.dumps() == "while True:\n    pass\n    if a:\n        pass\n\n"
 
 
+def test_line_proxy_correctly_indent_try():
+    red = RedBaron("def test():\n    try:\n        pass\n    except:\n        pass\n    finally:\n    pass")
+    red.append("c")
+    assert red.dumps() == "def test():\n    try:\n        pass\n    except:\n        pass\n    finally:\n    pass\nc\n"
+
+
 def test_root_as_line_proxy_list_len():
     red = RedBaron("a\nb\nc\n")
     assert len(red) == 3


### PR DESCRIPTION
Uses `_get_last_member_to_clean` if the node implements it.

Otherwise when the `LineProxyList` is regenerating it picks up the wrong last node for `TryNode` (as the except and finally "children" nodes aren't part of the values node list). This means it ends up closing the indentation on the `except:` line rather than after the try block as intended.